### PR TITLE
Fix version command

### DIFF
--- a/cmd/proaction/cli/version.go
+++ b/cmd/proaction/cli/version.go
@@ -19,7 +19,7 @@ func VersionCmd() *cobra.Command {
 			if err != nil {
 				fmt.Printf("\nUnable to check for newer releases: %s\n", err.Error())
 			} else if !isLatest {
-				fmt.Printf("\nVersion %s is available for proaction. To install updates, run\n  $ curl https://proaction.io/install | bash\n", latestVer)
+				fmt.Printf("\nVersion %s of Proaction is available.\n\nTo install the latest version, please visit https://proaction.io/docs/getting-started/installing/\n\n", latestVer)
 			}
 
 			return nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -83,7 +83,7 @@ func IsLatestRelease() (bool, string, error) {
 }
 
 func isLatestRelease(client *http.Client, upstream string) (bool, string, error) {
-	resp, err := client.Get(upstream + "/install?version")
+	resp, err := client.Get(upstream)
 	if err != nil {
 		return false, "", errors.Wrapf(err, "find latest release")
 	}


### PR DESCRIPTION
This fixed the version command to check for latest version using the correct URL and also print correct instructions when it's outdated.