### PR TITLE
Fix panic in unmarshaling cron

### DIFF
--- a/pkg/workflow/types/trigger.go
+++ b/pkg/workflow/types/trigger.go
@@ -191,7 +191,7 @@ func (me *MultiEvent) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		case "schedule":
 			scheduleEvent := ScheduleEvent{}
 			for _, v := range rawVal.([]interface{}) {
-				vv := v.(map[interface{}]interface{})
+				vv := v.(map[string]interface{})
 				if vvv, ok := vv["cron"]; ok {
 					scheduleEvent.Crons = append(scheduleEvent.Crons, Cron{CronField: vvv.(string)})
 				}


### PR DESCRIPTION
This is fixing a panic when a workflow has a cron because the unmarshaler was incorrect:

```
panic: interface conversion: interface {} is map[string]interface {}, not map[interface {}]interface {} [recovered]
        panic: interface conversion: interface {} is map[string]interface {}, not map[interface {}]interface {} [recovered]
        panic: interface conversion: interface {} is map[string]interface {}, not map[interface {}]interface {}

goroutine 1 [running]:
gopkg.in/yaml%2ev3.handleErr(0xc000117930)
        /home/marc/go/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c/yaml.go:276 +0x9a
panic(0x999fc0, 0xc000228810)
        /usr/local/go/src/runtime/panic.go:967 +0x166
gopkg.in/yaml%2ev3.handleErr(0xc000117120)
        /home/marc/go/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c/yaml.go:276 +0x9a
panic(0x999fc0, 0xc000228810)
        /usr/local/go/src/runtime/panic.go:967 +0x166
github.com/proactionhq/proaction/pkg/workflow/types.(*MultiEvent).UnmarshalYAML(0xc0001ac0e0, 0xc000382400, 0xf0b698, 0x0)
        /home/marc/go/src/github.com/proactionhq/proaction/pkg/workflow/types/trigger.go:194 +0xf30
```