### PR TITLE
Recommend tags when possible

### DIFF
--- a/pkg/checks/policies.go
+++ b/pkg/checks/policies.go
@@ -233,6 +233,7 @@ recommendations[output] {
 }
 
 # unstable if it's any branch, unless a recommendation is a branch
+## and there are no tags
 recommendations[output] {
   repo := input.repos[_]
   repo.refType == "branch"
@@ -243,7 +244,20 @@ recommendations[output] {
   ## know about the branch, and will update
   ## to the latest commit
   ## TODO ^^
+
+  count(repo.tags) == 0
   recommendation := recommendLatestCommit(repo)
+  output := buildOutput(repo, "isBranch", recommendation)
+}
+
+# unstable if it's any branch, unless a recommendation is a branch
+## and there are tags
+recommendations[output] {
+  repo := input.repos[_]
+  repo.refType == "branch"
+
+  count(repo.tags) > 0
+  recommendation := recommendLatestTag(repo)
   output := buildOutput(repo, "isBranch", recommendation)
 }
 `

--- a/pkg/checks/unstable-github-ref.rego
+++ b/pkg/checks/unstable-github-ref.rego
@@ -48,6 +48,7 @@ recommendations[output] {
 }
 
 # unstable if it's any branch, unless a recommendation is a branch
+## and there are no tags
 recommendations[output] {
   repo := input.repos[_]
   repo.refType == "branch"
@@ -58,6 +59,19 @@ recommendations[output] {
   ## know about the branch, and will update
   ## to the latest commit
   ## TODO ^^
+
+  count(repo.tags) == 0
   recommendation := recommendLatestCommit(repo)
+  output := buildOutput(repo, "isBranch", recommendation)
+}
+
+# unstable if it's any branch, unless a recommendation is a branch
+## and there are tags
+recommendations[output] {
+  repo := input.repos[_]
+  repo.refType == "branch"
+
+  count(repo.tags) > 0
+  recommendation := recommendLatestTag(repo)
   output := buildOutput(repo, "isBranch", recommendation)
 }


### PR DESCRIPTION
If an action is using a branch, Proaction was recommending a move to the commit. This PR changes this default behavior and instead, recommends moving to the latest tag.

